### PR TITLE
Add missing directory level 'bin'

### DIFF
--- a/Procfile.windows
+++ b/Procfile.windows
@@ -1,1 +1,1 @@
-web: build\install\gradle-getting-started\gradle-getting-started.bat
+web: build\install\gradle-getting-started\bin\gradle-getting-started.bat


### PR DESCRIPTION
When I followed the tutorial on my Windows machine I noticed that Windows procfile didn't match the Linux procfile as closely as I'd expected.  I eventually confirmed that the /bin/ directory level is necessary to run 'heroku local -f Procfile.windows' successfully.