### PR TITLE
Let database exceptions propagate as HTTP 500

### DIFF
--- a/src/main/java/com/heroku/java/GettingStartedApplication.java
+++ b/src/main/java/com/heroku/java/GettingStartedApplication.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -27,7 +28,7 @@ public class GettingStartedApplication {
     }
 
     @GetMapping("/database")
-    String database(Map<String, Object> model) {
+    String database(Map<String, Object> model) throws SQLException {
         try (Connection connection = dataSource.getConnection()) {
             final var statement = connection.createStatement();
             statement.executeUpdate("CREATE TABLE IF NOT EXISTS ticks (tick timestamp)");
@@ -41,10 +42,6 @@ public class GettingStartedApplication {
 
             model.put("records", output);
             return "database";
-
-        } catch (Throwable t) {
-            model.put("message", t.getMessage());
-            return "error";
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,4 @@ server.port=${PORT:5000}
 # application. Production applications should not have a default like this, especially not ones that have credentials
 # in them!
 spring.datasource.url=${JDBC_DATABASE_URL:jdbc:postgresql://example.com:5432/database}
+server.error.include-message=always


### PR DESCRIPTION
- Remove the `catch (Throwable t)` block from the `/database` endpoint that swallowed connection failures and returned HTTP 200 with an error template
- Declare `throws SQLException` so Spring Boot's default error handling returns a proper 500 status

This is the same fix applied in heroku/java-getting-started#239. Without it, `curl --fail` can't detect database connection failures, and downstream queries fail with `relation "ticks" does not exist`.
